### PR TITLE
A: g1.globo.com

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_hide.txt
+++ b/easylistportuguese/easylistportuguese_specific_hide.txt
@@ -222,3 +222,5 @@ ecoregional.com.br##.g-single
 ecoregional.com.br##.td-a-rec
 r7.com##.widget-24x1-ultimas__taboola
 r7.com##.r7-flex-adv__placeholder
+g1.globo.com##.publicidade.publicidade-banner_slb_topo
+g1.globo.com##.publicidade.publicidade-banner_slb_meio


### PR DESCRIPTION
Hides empty placeholders that show up only when AA is on

<img width="1387" alt="g2" src="https://user-images.githubusercontent.com/57706597/118774181-d80fb000-b885-11eb-8fe1-42bb44f69f0b.png">
<img width="1138" alt="g1" src="https://user-images.githubusercontent.com/57706597/118774167-d5ad5600-b885-11eb-87a1-c2280f199d6f.png">
