### PR TITLE
A: https://futemax.gratis/

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_block_popup.txt
+++ b/easylistportuguese/easylistportuguese_specific_block_popup.txt
@@ -1,5 +1,6 @@
 $popup,third-party,domain=streamtape.cc|redirect-ads.com
 ||futemax.live/imagens/logo2.png$popup
+||futemax.gratis/imagens/logo2.png$popup
 ||buylnk.com^$popup,domain=gfilmes.net
 /jump/next.php?$popup,domain=yts.mx
 ||landings.ncm*.com^$popup,domain=mrpiracy.top

--- a/easylistportuguese/easylistportuguese_specific_hide.txt
+++ b/easylistportuguese/easylistportuguese_specific_hide.txt
@@ -96,7 +96,7 @@ brasilescola.uol.com.br##div[style="width: 300px; height: 600px;"]
 mrpiracy.top##a[class^="reserve-button"]
 torredevigilancia.com##.singleBannerWidget
 metropoles.com##.container>.m-coupons-title
-futemax.fm,futemax.live##.alertWS
+futemax.fm,futemax.live,futemax.gratis##.alertWS
 animesonlinebr.co##a[title="pokemon"]
 portalmie.com##a[href*="portalmie.com/campanhas_empresas/"]
 infoescola.com##div[id^="index-banner"]


### PR DESCRIPTION
@jabonsolo add filter: `||futemax.gratis/imagens/logo2.png$popup` to block redirect popup on **futemax.gratis** + added its domain to filter: futemax.fm,futemax.live##.alertWS in order to hide the popup window itself since it keep coming up whether you click on any content.

<img width="604" alt="fm" src="https://user-images.githubusercontent.com/57706597/125092327-86d7ac00-e0d1-11eb-92b5-5ebbf4240b88.png">
