### PR TITLE
A: tecmundo.com.br

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_hide.txt
+++ b/easylistportuguese/easylistportuguese_specific_hide.txt
@@ -237,3 +237,4 @@ mrpiracy.top##a[class^="super-r-button"]
 astrologiaenlinea.com##td[width="728"][height="90"]
 caras.uol.com.br##.top-banner
 caras.uol.com.br##amp-fx-flying-carpet
+tecmundo.com.br##div[id^="slider-partner"]


### PR DESCRIPTION
Filter: `tecmundo.com.br##div[id^="slider-partner"]` to hide overlay ad on [tecmundo.com.br](https://www.tecmundo.com.br/) that show up after closing adblock wall message (you have the option to close it without having to disable ABP). [Sample URL](https://www.tecmundo.com.br/mobilidade-urbana-smart-cities/143794-drone-foguete-usado-morador-irritado-acabar-com-festa-rua.htm?f)

<img width="1159" alt="tm" src="https://user-images.githubusercontent.com/57706597/126521404-42846647-b533-463a-98fb-061e67041421.png">

