### PR TITLE
A: noticiasdecoimbra.pt

### DIFF
--- a/easylistportuguese/easylistportuguese_adservers.txt
+++ b/easylistportuguese/easylistportuguese_adservers.txt
@@ -84,3 +84,4 @@
 ||samplerpouch.com^$third-party
 ||loftsbaacad.com^$third-party
 ||deliriousglowing.com^$third-party
+||skoiy.xyz^$third-party

--- a/easylistportuguese/easylistportuguese_specific_block.txt
+++ b/easylistportuguese/easylistportuguese_specific_block.txt
@@ -97,3 +97,4 @@
 ||ecoregional.com.br/wp-content/uploads/*/jardim-pq-*.jpg
 ||ecoregional.com.br/wp-content/plugins/icegram/
 ||notebookcheck.info/fileadmin/Sonstiges/ama_abn2_$xmlhttprequest
+||noticiasdecoimbra.pt/*/modal/*/modal.min*^$stylesheet,script

--- a/easylistportuguese/easylistportuguese_specific_hide.txt
+++ b/easylistportuguese/easylistportuguese_specific_hide.txt
@@ -238,3 +238,5 @@ astrologiaenlinea.com##td[width="728"][height="90"]
 caras.uol.com.br##.top-banner
 caras.uol.com.br##amp-fx-flying-carpet
 tecmundo.com.br##div[id^="slider-partner"]
+noticiasdecoimbra.pt##div[id^="mvp-leader-wrap"]
+noticiasdecoimbra.pt##div[class*="cp_id_"]


### PR DESCRIPTION
Rules to block ads on [noticiasdecoimbra.pt](https://www.noticiasdecoimbra.pt/)
1 - `|noticiasdecoimbra.pt/*/modal/*/modal.min*^$stylesheet,script` blocks popup ad overlay (shows up before the cookie consent message and push notification)
2 - `noticiasdecoimbra.pt##div[id^="mvp-leader-wrap"]` hides the ad on the top (before the website logo)
3 - `||skoiy.xyz^$third-party` block skoiy ads on the article pages - [sample URL](https://www.noticiasdecoimbra.pt/toquio2020-portugal-oitavo-na-final-de-ensino-em-equestre/)
4 - `noticiasdecoimbra.pt##div[class*="cp_id_"]` hide ads on the bottom of the article pages

<img width="1395" alt="adtpv" src="https://user-images.githubusercontent.com/57706597/127190080-8fe16afb-4809-45f9-9ff2-aa6e664840d7.png">
<img width="1171" alt="adbt" src="https://user-images.githubusercontent.com/57706597/127190156-418a20fb-74d8-4e3b-bec3-9ea7657b38e6.png">
<img width="979" alt="skoiy1" src="https://user-images.githubusercontent.com/57706597/127190183-96411407-e07b-4903-a021-4849869771b1.png">
<img width="1234" alt="skoiy2" src="https://user-images.githubusercontent.com/57706597/127190197-ca408e06-13d2-4a65-9699-a462bfee0aa0.png">
