### PR TITLE
A: milkpoint.com.br

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_hide.txt
+++ b/easylistportuguese/easylistportuguese_specific_hide.txt
@@ -241,3 +241,4 @@ tecmundo.com.br##div[id^="slider-partner"]
 noticiasdecoimbra.pt##div[id^="mvp-leader-wrap"]
 noticiasdecoimbra.pt##div[class*="cp_id_"]
 brasil247.com##.adBackground
+milkpoint.com.br##a[class^="lnkbn"]


### PR DESCRIPTION
Adding rule: `milkpoint.com.br##a[class^="lnkbn"]` to hide image ads throughout the page. [Sample URL](https://www.milkpoint.com.br/noticias-e-mercado/giro-noticias/nielsen-mulheres-sao-responsaveis-pelas-compras-em-96-dos-lares-213129/)