### PR TITLE
A: topflix.vc

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_block_popup.txt
+++ b/easylistportuguese/easylistportuguese_specific_block_popup.txt
@@ -1,6 +1,7 @@
 $popup,third-party,domain=streamtape.cc|redirect-ads.com
 ||futemax.live/imagens/logo2.png$popup
 ||futemax.gratis/imagens/logo2.png$popup
+||topflix.vc/images/logo1.png$popup
 ||buylnk.com^$popup,domain=gfilmes.net
 /jump/next.php?$popup,domain=yts.mx
 ||landings.ncm*.com^$popup,domain=mrpiracy.top


### PR DESCRIPTION
Add `||topflix.vc/images/logo1.png$popup` to block redirect popup on [topflix.vc](https://topflix.vc/filmes/assistir-online-dupla-explosiva-2-e-a-primeira-dama-do-crime/)

Steps to reproduce: When you click on the first option of "Players Disponiveis"  it opens a new popup with https://topflix.vc/images/logo1.png and it redirects to: https://thaveksi.net/4401564.html?q  (for example)

<img width="1397" alt="tf1" src="https://user-images.githubusercontent.com/57706597/128888832-9ca3d275-e22f-4f04-ac76-f8a833536f31.png">
<img width="1130" alt="tf2" src="https://user-images.githubusercontent.com/57706597/128888849-f5dd0e3c-1558-47c1-93bf-035431df9f22.png">
