### PR TITLE
A: fogaonet.com

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_hide.txt
+++ b/easylistportuguese/easylistportuguese_specific_hide.txt
@@ -243,3 +243,4 @@ noticiasdecoimbra.pt##div[class*="cp_id_"]
 brasil247.com##.adBackground
 milkpoint.com.br##a[class^="lnkbn"]
 publishnews.com.br##div[class^="pn-anuncio"]
+fogaonet.com##div[class*="fnad-block"]


### PR DESCRIPTION
Adds rule: `fogaonet.com##div[class*="fnad-block"]` to hide placeholders on [fogaonet.com](https://www.fogaonet.com/) including [subpages](https://www.fogaonet.com/noticias-do-botafogo/entusiasmado-ceo-botafogo-nota-rafael-havera-reuniao-segunda/)

Below rules from EL seem not enough to hide that
```
##.pp-box-adunit 
##.pp-adunit
```
<img width="1404" alt="fogaonet" src="https://user-images.githubusercontent.com/57706597/132243714-953690f6-cfee-4c13-80e4-884eeb14df45.png">
