### PR TITLE
M: netvasco.com.br

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_hide.txt
+++ b/easylistportuguese/easylistportuguese_specific_hide.txt
@@ -243,3 +243,4 @@ noticiasdecoimbra.pt##div[class*="cp_id_"]
 brasil247.com##.adBackground
 milkpoint.com.br##a[class^="lnkbn"]
 publishnews.com.br##div[class^="pn-anuncio"]
+fogaonet.com##div[class*="fnad-block"]

--- a/easylistportuguese/easylistportuguese_specific_hide.txt
+++ b/easylistportuguese/easylistportuguese_specific_hide.txt
@@ -50,7 +50,7 @@ palcomp3.com##.banner_topo
 netvasco.com.br##.bannerquadrado
 expressomt.com.br##.banners
 uol.com.br##.bannersticky-top-container
-netvasco.com.br##.bannervertical
+netvasco.com.br##a[href^="https://bit.ly/Netvasco-Banner-"]
 record.pt##.bb
 extra.com.br##.bnr
 diarioonline.com.br##.box-banner


### PR DESCRIPTION
Suggestion to replace `netvasco.com.br##.bannervertical` with `netvasco.com.br##a[href^="https://bit.ly/Netvasco-Banner-"]`
since **##.bannervertical** also hides selfpromo that links to their [webshop](https://www.vascoboutique.com.br/).

<img width="1431" alt="ntvs" src="https://user-images.githubusercontent.com/57706597/132246079-2692cd38-c060-4a1f-a03e-cec3108508ee.png">
