### PR TITLE
A: vagalume.com.br

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_hide.txt
+++ b/easylistportuguese/easylistportuguese_specific_hide.txt
@@ -244,3 +244,4 @@ brasil247.com##.adBackground
 milkpoint.com.br##a[class^="lnkbn"]
 publishnews.com.br##div[class^="pn-anuncio"]
 fogaonet.com##div[class*="fnad-block"]
+vagalume.com.br###cazamba_vagalume_passback_container


### PR DESCRIPTION
Filter to hide sticky ad on [vagalume.com.br](https://www.vagalume.com.br/) it also happens on subpages
`vagalume.com.br###cazamba_vagalume_passback_container`

<img width="1398" alt="vglm" src="https://user-images.githubusercontent.com/65717387/132502671-b9917cc3-02dc-4008-8f4c-31cd6f520d47.png">


