### PR TITLE
A: maisesports.com.br

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_block.txt
+++ b/easylistportuguese/easylistportuguese_specific_block.txt
@@ -98,3 +98,4 @@
 ||ecoregional.com.br/wp-content/plugins/icegram/
 ||notebookcheck.info/fileadmin/Sonstiges/ama_abn2_$xmlhttprequest
 ||noticiasdecoimbra.pt/*/modal/*/modal.min*^$stylesheet,script
+||s3.amazonaws.com/strapi-uploads/*.png$image,domain=maisesports.com.br

--- a/easylistportuguese/easylistportuguese_specific_hide.txt
+++ b/easylistportuguese/easylistportuguese_specific_hide.txt
@@ -245,3 +245,4 @@ milkpoint.com.br##a[class^="lnkbn"]
 publishnews.com.br##div[class^="pn-anuncio"]
 fogaonet.com##div[class*="fnad-block"]
 vagalume.com.br###cazamba_vagalume_passback_container
+maisesports.com.br##a[href^="https://mais.gg/cyberbet"]


### PR DESCRIPTION
Hiding and Blocking filter for [maisesports](https://maisesports.com.br/)

Hiding (to hide the link to the ads for the placeholders on the top and ads on the sides): `maisesports.com.br##a[href^="https://mais.gg/cyberbet"] `

Blocking [Image background](https://elasticbeanstalk-us-east-1-909474674380.s3.amazonaws.com/strapi-uploads//cyberbet_background_2_8b3bc4cd1f.png) on both sides : `||s3.amazonaws.com/strapi-uploads/*.png$image,domain=maisesports.com.br`

<img width="1400" alt="msp" src="https://user-images.githubusercontent.com/65717387/133242225-ae6bef74-4cd6-49b2-ab42-f3dc4d3f87b9.png">

Seems it's not possible to hide the placeholder on the top because it's part of the background.