### PR TITLE
A: betnabola.com.br

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_hide.txt
+++ b/easylistportuguese/easylistportuguese_specific_hide.txt
@@ -245,3 +245,4 @@ milkpoint.com.br##a[class^="lnkbn"]
 publishnews.com.br##div[class^="pn-anuncio"]
 fogaonet.com##div[class*="fnad-block"]
 vagalume.com.br###cazamba_vagalume_passback_container
+betnabola.com.br##section[id^="bouplay_wp_"]


### PR DESCRIPTION
Hiding filter for [betnabola](https://betnabola.com.br/).

Filter: `betnabola.com.br##section[id^="bouplay_wp_"]`

<img width="1439" alt="Screenshot 2021-09-14 at 08 06 43" src="https://user-images.githubusercontent.com/65717387/133246754-a337d03f-896e-47e5-a55f-771e6e128c34.png">
