### PR TITLE
A: blog.tudogostoso.com.br

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_hide.txt
+++ b/easylistportuguese/easylistportuguese_specific_hide.txt
@@ -245,3 +245,5 @@ milkpoint.com.br##a[class^="lnkbn"]
 publishnews.com.br##div[class^="pn-anuncio"]
 fogaonet.com##div[class*="fnad-block"]
 vagalume.com.br###cazamba_vagalume_passback_container
+blog.tudogostoso.com.br##div[data-iab-tag^="content_header_"]
+blog.tudogostoso.com.br##div[class^="showcase-box arroba"]


### PR DESCRIPTION
Specific Hiding filter for [Blog.tudogostoso](https://blog.tudogostoso.com.br/)

Header filter : `blog.tudogostoso.com.br##div[data-iab-tag^="content_header_"]`
to hide side placeholders : `blog.tudogostoso.com.br##div[class^="showcase-box arroba"]`

<img width="1399" alt="btg" src="https://user-images.githubusercontent.com/65717387/133254210-4dc5d2c3-194e-45ee-879e-4f6a9ccb9425.png">


