### PR TITLE
A: allowing bet365 and 1xbet popups

### DIFF
--- a/easylistportuguese/easylistportuguese_allowlist_popup.txt
+++ b/easylistportuguese/easylistportuguese_allowlist_popup.txt
@@ -1,0 +1,2 @@
+@@||bet365.com^*affiliate=$popup
+@@||refpa.top^$popup

--- a/easylistportuguese/easylistportuguese_allowlist_popup.txt
+++ b/easylistportuguese/easylistportuguese_allowlist_popup.txt
@@ -1,2 +1,2 @@
-@@||bet365.com^*affiliate=$popup
-@@||refpa.top^$popup
+@@||bet365.com^*affiliate=$popup,domain=academiadasapostasbrasil.com|sites-de-apostas.net|postasesportivas24.net|futebolnaveia.com.br|footballpredictions.net
+@@||refpa.top^$popup,domain=academiadasapostasbrasil.com|sites-de-apostas.net|postasesportivas24.net|futebolnaveia.com.br|footballpredictions.net


### PR DESCRIPTION
Adding exception to PTlist regarding filters blocking part of the content on below bet websites

```
@@||bet365.com^*affiliate=$popup
@@||refpa.top^$popup
```

EL filters: `||bet365.com^*affiliate=$popup` and `||refpa.top^$popup` prevent bet365 and 1Xbet popups links from opening on:  https://www.academiadasapostasbrasil.com/ 
including subpages: https://www.academiadasapostasbrasil.com/promotions/reviews 

General examples of webpages blocking the popups: 
www.academiadasapostasbrasil.com
https://www.sites-de-apostas.net
www.apostasesportivas24.net
https://www.futebolnaveia.com.br
https://footballpredictions.net/pt

<img width="1206" alt="beta" src="https://user-images.githubusercontent.com/65717387/133619434-d1c29637-250e-40b5-8bc1-f2ef2f8dac68.png">
<img width="1028" alt="betac" src="https://user-images.githubusercontent.com/65717387/133619464-6cf5b72e-c2a8-4d76-b44f-54d8a1939a42.png">
<img width="1201" alt="betb" src="https://user-images.githubusercontent.com/65717387/133619473-8651c832-eed8-4a46-94c0-182ad42d1f6c.png">
<img width="1116" alt="betting" src="https://user-images.githubusercontent.com/65717387/133619632-b01d2934-34a7-4b3f-9f3a-afa80a4e2920.png">


We also noticed that we have a lot of webpages blocking the popups on the Spanish EL, should we also add this exceptions in there ? 

Thank you in advance.
