### PR TITLE
A: naoconto.com [NSFW]

### DIFF
--- a/easylistportuguese_adult/adult_specific_hide.txt
+++ b/easylistportuguese_adult/adult_specific_hide.txt
@@ -3,3 +3,5 @@ meuscontoseroticos.com#?#:-abp-has(> a > div > div > span.thumb-ads)
 meuscontoseroticos.com#?#:-abp-has(> div.contoConteudo > div.conto-thumb > a[rel^="nofollow"])
 nudelas.com###adstopo
 nudelas.com##li[id^="njads_single_widget-"]
+naoconto.com##a[href^="https://www.vivalocal.com"]
+naoconto.com##a[href^="https://www.camerahot.com"]


### PR DESCRIPTION
Filters for [naoconto](https://www.naoconto.com/) [NSFW]. 

The request was made via the issue #https://github.com/easylist/easylistportuguese/issues/75 , The best way i've found to avoid the ads were via hiding filters, as we had 2 ahref's as parents and a video and image as child's. For that reason i've chose the filters bellow: 

```
naoconto.com##a[href^="https://www.vivalocal.com"]
naoconto.com##a[href^="https://www.camerahot.com"]
```

PS: All the info and screenshots are inside the issue referred above.