### PR TITLE
A: mulheresafoder.com [NSFW]

### DIFF
--- a/easylistportuguese/easylistportuguese_general_block.txt
+++ b/easylistportuguese/easylistportuguese_general_block.txt
@@ -47,3 +47,4 @@ _publicidade.
 _publicidade_
 ||solution.coupons^$script,third-party
 ||seedtag.com^$third-party,domain=~seedtag.com
+||bloco.top$script,image,third-party

--- a/easylistportuguese_adult/adult_specific_hide.txt
+++ b/easylistportuguese_adult/adult_specific_hide.txt
@@ -5,3 +5,5 @@ nudelas.com###adstopo
 nudelas.com##li[id^="njads_single_widget-"]
 naoconto.com##a[href^="https://www.vivalocal.com"]
 naoconto.com##a[href^="https://www.camerahot.com"]
+mulheresafoder.com###aumento
+mulheresafoder.com###sexdate


### PR DESCRIPTION
Filters for [mulheresafoder](https://www.mulheresafoder.com/) [NSFW]. 
An issue was opened for this specific webpage #https://github.com/easylist/easylistportuguese/issues/80 
While creating the filters i've found another ad in the left side (Together with the other videos).

My proposal is: 
General blocking filter : `||bloco.top$script,image,third-party` (It can be also in non-adult webpages)
Adult specific hiding filter for the placeholders : 
```
mulheresafoder.com###aumento
mulheresafoder.com###sexdate
```

All the data and screenshots for this PR are inside the Issue mentioned above.