### PR TITLE
A: novinhasdozapzap.com [NSFW]

### DIFF
--- a/easylistportuguese_adult/adult_specific_hide.txt
+++ b/easylistportuguese_adult/adult_specific_hide.txt
@@ -5,3 +5,4 @@ nudelas.com###adstopo
 nudelas.com##li[id^="njads_single_widget-"]
 naoconto.com##a[href^="https://www.vivalocal.com"]
 naoconto.com##a[href^="https://www.camerahot.com"]
+novinhasdozapzap.com###text-59


### PR DESCRIPTION
Filter for [novinhasdozapzap](https://novinhasdozapzap.com/) requested via Issue #https://github.com/easylist/easylistportuguese/issues/70

I've tried to block the images (Gifs), but there are other 2 or 3 that are part of the content, another thing is as reported on the issue there is a part called parceiros (partners), on this way i believe it's also part of the webpage. For that reason i decided to go for a really specific hiding filter: `novinhasdozapzap.com###text-59`

All the info and Screenshots are inside the Issue mentioned above. 