### PR TITLE
A: betteranime.net

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_hide.txt
+++ b/easylistportuguese/easylistportuguese_specific_hide.txt
@@ -262,3 +262,4 @@ areah.com.br###banner_top
 areah.com.br##div[class^="banner_footer"]
 futebolbrasil.online##.padd20
 futebolbahiano.org##[id^="custom_html-2"]
+betteranime.net##.drts


### PR DESCRIPTION
Filter for hiding popup at the page [betteranime-episode182](https://betteranime.net/anime/legendado/one-piece/episodio-182).

I couldn't find a proper JS file to block the pop up, neither a correct iframe as they use a randomised class, for that my solution was to block the class responsible for the popup block: `betteranime.net##.drts` 

Screenshot:
![e74fd25b-f78e-4403-bbcf-a8e9a72501e4](https://user-images.githubusercontent.com/65717387/134671691-9a6af972-462a-4739-9f15-5936d260f1fd.png)
 
