### PR TITLE
A: manhwa18.cc [NSFW]

### DIFF
--- a/easylistportuguese_adult/adult_specific_block.txt
+++ b/easylistportuguese_adult/adult_specific_block.txt
@@ -7,3 +7,5 @@
 ||contoerotico.com/adscod/
 ||cameracaseira.com^$script,domain=videosdesuavizinha.com
 ||parlorscenes.com^$script
+||rowensalmner.com^$script,third-party
+||manhwa18.cc/bmoa^$script


### PR DESCRIPTION
Filters for blocking scripts responsible for emerging popups and ads in all the pages at [manhwa18](https://manhwa18.cc/) 

Proposed blocking filters: 
Popups: `||rowensalmner.com^$script,third-party`
Exoclick ads: `||manhwa18.cc/bmoa^$script`

Screenshots:
<img width="1440" alt="Screenshot 2021-09-30 at 08 45 54" src="https://user-images.githubusercontent.com/65717387/135450269-2b47e42d-acbb-49e9-a633-316d6d057f25.png">
<img width="1440" alt="Screenshot 2021-09-30 at 08 47 01" src="https://user-images.githubusercontent.com/65717387/135450287-4200f003-aa1f-46db-b22b-14c07cf8ed2d.png">


