### PR TITLE
A: multicanais.tv

### DIFF
--- a/easylistportuguese/easylistportuguese_general_block.txt
+++ b/easylistportuguese/easylistportuguese_general_block.txt
@@ -48,3 +48,4 @@ _publicidade_
 ||solution.coupons^$script,third-party
 ||seedtag.com^$third-party,domain=~seedtag.com
 ||bloco.top$script,image,third-party
+||cdnstatic.cyber.bet$script,third-party


### PR DESCRIPTION
Filters for blocking script related to bet ads at [multicanais](https://multicanais.tv/assistir-flamengo-x-barcelona-equ-ao-vivo-online-hd-22-09-2021/)

Proposed filter: `||cdnstatic.cyber.bet$script,third-party`

Screenshot:
<img width="1440" alt="Screenshot 2021-09-30 at 09 34 35" src="https://user-images.githubusercontent.com/65717387/135455832-45e4f944-f181-4364-9395-34080c62af08.png">

