### PR TITLE
A: reportermt.com.br

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_block.txt
+++ b/easylistportuguese/easylistportuguese_specific_block.txt
@@ -104,3 +104,4 @@
 ||i1.wp.com/www.cenariomt.com.br/wp-content/uploads/*/provincia-at.png
 /_next/image?url=*s3.amazonaws.com$domain=maisesports.com.br
 ||adlyra.com$subdocument,third-party
+||reportermt.nyc3.digitaloceanspaces.com/*/original$image

--- a/easylistportuguese/easylistportuguese_specific_hide.txt
+++ b/easylistportuguese/easylistportuguese_specific_hide.txt
@@ -267,3 +267,4 @@ futebolbrasil.online##.padd20
 futebolbahiano.org##[id^="custom_html-2"]
 sofilmeshd.piracyproxy.info##[id^="cookieConsent"]
 animesgratisbr.biz##img[title^="Assistir Hentai"]
+


### PR DESCRIPTION
Filters for blocking images path related to ads all over the pages at [reportermt](https://www.reportermt.com.br/)

Proposed filter: `||reportermt.nyc3.digitaloceanspaces.com/*/original$image`

Screenshots: 
<img width="1440" alt="Screenshot 2021-10-05 at 08 05 12" src="https://user-images.githubusercontent.com/65717387/136012148-372f25c2-4238-4e79-ba85-e88c43b70fd3.png">
<img width="1440" alt="Screenshot 2021-10-05 at 08 04 58" src="https://user-images.githubusercontent.com/65717387/136012155-ea3e17be-5b9c-4812-9294-70e69912b95d.png">


