### PR TITLE
A: globalnoticias.com.br

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_block.txt
+++ b/easylistportuguese/easylistportuguese_specific_block.txt
@@ -104,3 +104,4 @@
 ||i1.wp.com/www.cenariomt.com.br/wp-content/uploads/*/provincia-at.png
 /_next/image?url=*s3.amazonaws.com$domain=maisesports.com.br
 ||adlyra.com$subdocument,third-party
+||globalnoticias.com.br/*/banners$image


### PR DESCRIPTION
Filter for blocking images path linked to ads at [globalnoticias](https://www.globalnoticias.com.br/)

Proposed filter: `||globalnoticias.com.br/*/banners$image`

PS: The "ji-parana"stuff on the right side of the logo webpage is also an ad. 

Screenshots:
<img width="1258" alt="Screenshot 2021-10-05 at 09 36 12" src="https://user-images.githubusercontent.com/65717387/136023627-2030bf79-2479-44bd-a5f1-1fe0769661e0.png">
<img width="1249" alt="Screenshot 2021-10-05 at 09 36 28" src="https://user-images.githubusercontent.com/65717387/136023638-7ec8c163-86e2-4cc5-8ae1-9c623296f766.png">
<img width="1440" alt="Screenshot 2021-10-05 at 09 36 40" src="https://user-images.githubusercontent.com/65717387/136023646-5a4fc5f4-96aa-4db4-b156-646a219ce011.png">


