### PR TITLE
A: maniacosporcomics.com [NSFW]

### DIFF
--- a/easylistportuguese/easylistportuguese_adservers.txt
+++ b/easylistportuguese/easylistportuguese_adservers.txt
@@ -89,3 +89,4 @@
 ||ihogaetw.com^$third-party  
 ||sdxqusoze.com^$third-party
 ||qjcdnpv.com^$third-party
+||www.dhilyjdw.com^$third-party


### PR DESCRIPTION
Filters for blocking adserver responsible for redirects for betting webpages at [maniacosporcomics](https://maniacosporcomics.com/)

Proposed filter: `||www.dhilyjdw.com^$third-party`

How to reproduce: At the main page try to open some of the comics, right after you are going to be redirected, after some seconds in "about blank"the link www.dhilyjdw.com will appear