### PR TITLE
A: futebolplayhd.com

### DIFF
--- a/easylistportuguese/easylistportuguese_adservers.txt
+++ b/easylistportuguese/easylistportuguese_adservers.txt
@@ -89,3 +89,4 @@
 ||ihogaetw.com^$third-party  
 ||sdxqusoze.com^$third-party
 ||qjcdnpv.com^$third-party
+||soonen.com^$third-party


### PR DESCRIPTION
Filter for blocking adserver responsible for redirect at [futebolplayhd](https://futebolplayhd.com/assistir-globo-rj-ao-vivo-24-horas-gratis/)

Proposed filter: `||soonen.com^$third-party`

How to reproduce the redirect: go to option 6 (link above), try to play the video, it will try to redirect to different webpages one of this adservers is the one above(soonen).