### PR TITLE
A: vizer.tv

### DIFF
--- a/easylistportuguese/easylistportuguese_adservers_popup.txt
+++ b/easylistportuguese/easylistportuguese_adservers_popup.txt
@@ -5,3 +5,4 @@
 ||toldmeflex.com^$popup,third-party
 ||glixaing.com^$popup,third-party
 ||doaseeph.com^$popup,third-party
+||ownerswifeimprove.com^$popup,third-party

--- a/easylistportuguese/easylistportuguese_adservers_popup.txt
+++ b/easylistportuguese/easylistportuguese_adservers_popup.txt
@@ -6,3 +6,5 @@
 ||glixaing.com^$popup,third-party
 ||doaseeph.com^$popup,third-party
 ||ownerswifeimprove.com^$popup,third-party
+||gnoyvsielusbi.xyz^$popup,third-party
+||glossarysack.com^$popup,third-party


### PR DESCRIPTION
Filter for blocking adserver popup at [vizer.tv](https://vizer.tv/filme/online/a-familia-mitchell-e-a-revolta-das-maquinas)

Proposed filter: `||ownerswifeimprove.com^$popup,third-party`

Screenshot and how to reproduce : 
click in "assistir", then select "original" and then the first proxy (mixdrop), after that click play till the popup page will appear.
<img width="1440" alt="Screenshot 2021-10-08 at 09 56 26" src="https://user-images.githubusercontent.com/65717387/136562087-d4b6a6e4-545e-47a6-bd9b-8b7bce5a1be5.png">
 
