### PR TITLE
A: br.bolavip.com

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_hide.txt
+++ b/easylistportuguese/easylistportuguese_specific_hide.txt
@@ -267,3 +267,4 @@ futebolbrasil.online##.padd20
 futebolbahiano.org##[id^="custom_html-2"]
 sofilmeshd.piracyproxy.info##[id^="cookieConsent"]
 animesgratisbr.biz##img[title^="Assistir Hentai"]
+br.bolavip.com##.boxbanner_container


### PR DESCRIPTION
Filter for hiding placeholders at [bolavip]( https://br.bolavip.com/cotidiano/Previsao-do-tempo-Chuva-prevalece-em-parte-do-pais-20211007-0009.html)

proposed filter: `br.bolavip.com##.boxbanner_container`

Screenshot:
<img width="1440" alt="Screenshot 2021-10-08 at 22 34 05" src="https://user-images.githubusercontent.com/65717387/136639296-069fc69f-f687-4547-96da-eae8889f6982.png">

