### PR TITLE
A: megahdfilmes.tv

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_block.txt
+++ b/easylistportuguese/easylistportuguese_specific_block.txt
@@ -105,3 +105,4 @@
 /_next/image?url=*s3.amazonaws.com$domain=maisesports.com.br
 ||adlyra.com$subdocument,third-party
 ||conjugacao-de-verbos.com/img/mosalingua/
+||imagineposition.com$script


### PR DESCRIPTION
Filter for blocking script responsible for redirects at [megahdfilmes](https://megahdfilmes.tv/filmes/727745-a-barraca-do-beijo-3/)

Proposed filter: `||imagineposition.com$script`

To reproduce, try to open the first server(proxy) and try to start the movie and pause.

<img width="1440" alt="Screenshot 2021-10-12 at 00 08 11" src="https://user-images.githubusercontent.com/65717387/136884653-c261ec7b-5430-4a93-9f97-8f1098d44633.png">