### PR TITLE
M: netvasco.com.br

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_hide.txt
+++ b/easylistportuguese/easylistportuguese_specific_hide.txt
@@ -50,7 +50,7 @@ palcomp3.com##.banner_topo
 netvasco.com.br##.bannerquadrado
 expressomt.com.br##.banners
 uol.com.br##.bannersticky-top-container
-netvasco.com.br##a[href^="https://bit.ly/Netvasco-Banner-"]
+netvasco.com.br##a[href^="https://bit.ly/Netvasco-Banner"]
 record.pt##.bb
 extra.com.br##.bnr
 diarioonline.com.br##.box-banner


### PR DESCRIPTION
Changing the filter at [netvasco](https://www.netvasco.com.br/)

They've changed the src and the ad was showing up once again.

<img width="1440" alt="Screenshot 2021-10-19 at 12 08 54" src="https://user-images.githubusercontent.com/65717387/137938936-de2dab93-b214-412e-a9f4-0383d5d17a84.png">


