### PR TITLE
A: revistabula.com

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_hide.txt
+++ b/easylistportuguese/easylistportuguese_specific_hide.txt
@@ -274,3 +274,4 @@ marriedgames.com.br##.aawp
 marriedgames.com.br##div[class^="angwp_"]
 portal.meusdividendos.com##section[class$="advertising"]
 poki.com.br##div[class^="Advertisement_"]
+revistabula.com##[href^="https://amzn.to/"]


### PR DESCRIPTION
Filter to hide ad at [revistabula](https://www.revistabula.com/)

proposed filter: `revistabula.com##[href^="https://amzn.to/"]`

Screenshot:
<img width="1411" alt="Screenshot 2021-10-19 at 21 32 38" src="https://user-images.githubusercontent.com/65717387/138008602-8c4b8ac2-9d06-4bad-ba40-a7aa45155a54.png">
