### PR TITLE
A: torrentfilmes4k.org

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_block_popup.txt
+++ b/easylistportuguese/easylistportuguese_specific_block_popup.txt
@@ -6,3 +6,4 @@ $popup,third-party,domain=streamtape.cc|redirect-ads.com
 /jump/next.php?$popup,domain=yts.mx
 ||landings.ncm*.com^$popup,domain=mrpiracy.top
 /3djuegos_media_v1^$popup,domain=3djuegos.com
+||bp.blogspot.com/*.jpg$popup


### PR DESCRIPTION
Filter for blocking specific redirect popups at [torrentfilmes4k](https://torrentfilmes4k.org/) while clicking in any content

Proposed filter: `||bp.blogspot.com/*.jpg$popup`

Screenhots:
<img width="1440" alt="Screenshot 2021-10-20 at 07 22 41" src="https://user-images.githubusercontent.com/65717387/138076659-a2db230f-a27d-48f8-ae58-1372fa0f305d.png">
<img width="1440" alt="Screenshot 2021-10-20 at 07 16 36" src="https://user-images.githubusercontent.com/65717387/138076673-beb1fc0a-86e0-49cd-8e78-754511793096.png">
 
