### PR TITLE
A: fabiorobertonoticias.com.br

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_hide.txt
+++ b/easylistportuguese/easylistportuguese_specific_hide.txt
@@ -274,3 +274,4 @@ marriedgames.com.br##.aawp
 marriedgames.com.br##div[class^="angwp_"]
 portal.meusdividendos.com##section[class$="advertising"]
 poki.com.br##div[class^="Advertisement_"]
+fabiorobertonoticias.com.br##td[width="750"]


### PR DESCRIPTION
Filter for hiding placeholder that appears while refreshing the page at [fabiorobertonoticias](http://www.fabiorobertonoticias.com.br/v1/ilheus/)

Proposed filter: `fabiorobertonoticias.com.br##td[width="750"]`

Screenshot:
<img width="1019" alt="w2" src="https://user-images.githubusercontent.com/65717387/138290515-d5ab1f0e-b49c-4f1c-887c-63da8c171530.png">

