### PR TITLE
A: revistanet.com.br

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_hide.txt
+++ b/easylistportuguese/easylistportuguese_specific_hide.txt
@@ -177,7 +177,7 @@ santiagomagazine.cv##.ne-banner-layout1
 jornaltransparencia.st###obj1
 odemocratagb.com###text-3
 odemocratagb.com###text-6
-jornalnoticias.co.mz##.bannergroup
+jornalnoticias.co.mz,revistanet.com.br##.bannergroup
 moznews.co.mz##.wpb_content_element
 folhademaputo.co.mz##.bg-pattern-hatch
 brasil247.com##.ad-first-text


### PR DESCRIPTION
Filter for hiding ads at [revistanet](https://revistanet.com.br/)

Proposed existing filter: `revistanet.com.br##.bannergroup`

Screenshots:
<img width="507" alt="Screenshot 2021-10-24 at 23 50 33" src="https://user-images.githubusercontent.com/65717387/138627610-e66a354f-3a07-440f-b680-59b745d90c9a.png">