### PR TITLE
A: megatorrentshd.net

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_block.txt
+++ b/easylistportuguese/easylistportuguese_specific_block.txt
@@ -113,3 +113,5 @@
 ||conjugacao-de-verbos.com/img/mosalingua/
 ||shrtfly.com/referral/$image
 ||paranaportal.uol.com.br/wp-content/*/tenuta$image
+||chishare.org$subdocument,third-party
+||verfilmes.biz$subdocument,third-party


### PR DESCRIPTION
Filter for blocking subdocuments responsible for ads at [megatorrents](http://megatorrentshd.net/o-atirador-2017-2a-temporada-720p-dual-audio-hd-1/)

Proposed filters: 
```
||chishare.org$subdocument,third-party
||verfilmes.biz$subdocument,third-party
```

Screenshots:
<img width="1439" alt="Screenshot 2021-10-25 at 00 02 18" src="https://user-images.githubusercontent.com/65717387/138629273-ab0c04db-f457-4e60-8e98-ca29aaa7c04f.png">
<img width="1440" alt="Screenshot 2021-10-24 at 23 56 01" src="https://user-images.githubusercontent.com/65717387/138629277-edbcef49-df72-4d5b-b81f-99fc3917e298.png">
 
