### PR TITLE
A: gofilmes.me

### DIFF
--- a/easylistportuguese/easylistportuguese_adservers.txt
+++ b/easylistportuguese/easylistportuguese_adservers.txt
@@ -91,3 +91,4 @@
 ||qjcdnpv.com^$third-party
 ||soonen.com^$third-party
 ||anansycoses.com^$third-party
+||foundchoked.com^$third-party


### PR DESCRIPTION
Filter for blocking adserver responsible for redirects at [gofilmes](https://gofilmes.me/cry-macho-o-caminho-para-redencao)

Proposed filter: `||foundchoked.com^$third-party`

How to reproduce: Go to the second proxy option (Second dublado) and try to start the video.