### PR TITLE
A: abril.com.br

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_hide.txt
+++ b/easylistportuguese/easylistportuguese_specific_hide.txt
@@ -34,7 +34,7 @@ olx.com.br###web_listing_banner_top
 belasmensagens.com.br,rostos.pt,terra.com.br,uol.com.br,vagalume.com.br,conectaimobi.com.br##.ad
 letras.mus.br##.ad-letra
 tiinside.com.br##.ad1
-em.com.br,gaz.com.br,grandepremio.com.br,infoescola.com,novojornal.co.ao,record.pt,tudocelular.com##.ads
+em.com.br,gaz.com.br,grandepremio.com.br,infoescola.com,novojornal.co.ao,record.pt,tudocelular.com,abril.com.br##.ads
 animeplus.org##.adsBody
 terra.com.br,uol.com.br##.advertising
 dw.com##.advertisement


### PR DESCRIPTION
Added domain: **abril.com.br** to an existing rule to hide placeholders on below pages:

### 1 - https://saude.abril.com.br/
<img width="1311" alt="pbg" src="https://user-images.githubusercontent.com/57706597/150974391-ee5e18f0-63f8-4759-ae8e-51dad54265ae.png">


### 2 - https://saude.abril.com.br/vida-animal/
<img width="1014" alt="pbj" src="https://user-images.githubusercontent.com/57706597/150974416-6e87da4d-23b5-4278-80d6-945ef885ffa6.png">


### 3 - https://saude.abril.com.br/coluna/com-a-palavra/sindrome-de-rokitansky/ 
<img width="987" alt="pbi" src="https://user-images.githubusercontent.com/57706597/150974941-1bb585ef-8580-46de-8a18-00dc179ccf9d.png">

- I was able to open [above article](https://saude.abril.com.br/coluna/com-a-palavra/sindrome-de-rokitansky/ ) page on Chrome without getting a paywall. I've seen Outbrain ads at the bottom of the page, in case you can reproduce it, rule: `||outbrain.com^$domain=abril.com.br` should block it.




