### PR TITLE
A: https://topflix.fm

### DIFF
--- a/easylistportuguese/easylistportuguese_adservers.txt
+++ b/easylistportuguese/easylistportuguese_adservers.txt
@@ -134,3 +134,6 @@
 ||vid95vl24x.com^$third-party
 ||auspiceguile.com^$third-party
 ||augu3yhd485st.com^$third-party
+||phouvemp.net^$third-party
+||ddnmbydtnfebyd.com^$third-party
+||vcrlaitlihy.com^$third-party

--- a/easylistportuguese/easylistportuguese_specific_block_popup.txt
+++ b/easylistportuguese/easylistportuguese_specific_block_popup.txt
@@ -1,7 +1,7 @@
 $popup,third-party,domain=cillylovers.com|streamtape.cc|redirect-ads.com|vizer.vip|vizer.tv|stape.fun
 ||futemax.live/imagens/logo2.png$popup
 ||futemax.gratis/imagens/logo2.png$popup
-||topflix.vc/images/logo1.png$popup
+||topflix.fm/images/logo1.png$popup
 ||buylnk.com^$popup,domain=gfilmes.net
 /jump/next.php?$popup,domain=yts.mx
 ||landings.ncm*.com^$popup,domain=mrpiracy.top


### PR DESCRIPTION
### 1 - Block redirect popups when you click on the play button (first server)

Sample URL: https://topflix.fm/filmes/assistir-online-homem-aranha-sem-volta-para-casa-online/

In case the website freezes with dev tools: **view-source:https://topflix.fm/filmes/assistir-online-homem-aranha-sem-volta-para-casa-online/**
<img width="532" alt="as1" src="https://user-images.githubusercontent.com/57706597/153870036-482bd7b0-d267-4e58-98f8-dcc95407fd91.png">
<img width="645" alt="as2" src="https://user-images.githubusercontent.com/57706597/153870037-ef973ef8-bf93-4572-af8e-5d7f6c956fa1.png">
<img width="639" alt="as3" src="https://user-images.githubusercontent.com/57706597/153870038-6a70dfd4-8de4-4f46-91b7-329c7016fbc6.png">


### 2 - Adjusted existing rule to block popup image (domain has changed):
[topflix.vc](http://topflix.vc) and [topflix.tv](http://topflix.tv/) are now [topflix.fm](http://topflix.fm/)
<img width="628" alt="as4" src="https://user-images.githubusercontent.com/57706597/153879248-62a3bf66-2524-4c8f-9ad1-ec71c61cb599.png">

<img width="1162" alt="tpf_i" src="https://user-images.githubusercontent.com/57706597/153879264-e9daf7b0-98fc-43a5-ba02-11c768213612.png">

