### PR TITLE
A: https://mangalivre.net/

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_hide.txt
+++ b/easylistportuguese/easylistportuguese_specific_hide.txt
@@ -341,3 +341,5 @@ nsctotal.com.br##[class^="AdUnit_"]
 nsctotal.com.br##.top-smad
 arnolds.com.br#?#center:-abp-has(p:-abp-contains(Publicidade))
 arnolds.com.br###custom_html-2
+mangalivre.net##.vignette-content
+mangalivre.net##[amazon-offers-list]


### PR DESCRIPTION
Hide ad placeholders (top and sidebar) and banner ad (bottom) at https://mangalivre.net/ler/one-piece/online/371782/1044#/!page0

<img width="1140" alt="ml1" src="https://user-images.githubusercontent.com/57706597/161152331-a11f3387-0f7f-4175-8d0c-323c5d76aa20.png">


<img width="1146" alt="ml2" src="https://user-images.githubusercontent.com/57706597/161152337-b8a4d6b2-c901-4d6d-ab1c-9d407ee7fac3.png">



`mangalivre.net##.vignette-content` is not enough to hide the Amazon ads so also adding `mangalivre.net##[amazon-offers-list]`
<img width="1366" alt="ml3" src="https://user-images.githubusercontent.com/57706597/161152349-3c918127-96b2-415e-b4ba-170f825f6cd5.png">




### Results with the filters (placeholders and bottom ad):
<img width="1219" alt="rt2" src="https://user-images.githubusercontent.com/57706597/161152715-a8e4d600-cedd-4f6c-a69c-0972cff44167.png">

<img width="1201" alt="rt1" src="https://user-images.githubusercontent.com/57706597/161152435-01ddbca6-cde2-46bf-8b35-faaa7d588ee3.png">

