### PR TITLE
A: https://xpanimes.com/

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_hide.txt
+++ b/easylistportuguese/easylistportuguese_specific_hide.txt
@@ -355,3 +355,4 @@ narutoonline.com.br###avisoPopup
 narutoonline.com.br##.modal-backdrop
 narutoonline.com.br##[id^="an"]
 portalnortedailha.com.br##.area-banner
+xpanimes.com##.container > div[style*="z-index:"]


### PR DESCRIPTION
Hide ad popup at  https://xpanimes.com/

Suggested filter: `xpanimes.com##.container > div[style*="z-index:"]`
<img width="1414" alt="xpa1" src="https://user-images.githubusercontent.com/57706597/163480369-9c4194f5-23a8-4afd-a2de-0b17c593212b.png">

<img width="1382" alt="xpa2" src="https://user-images.githubusercontent.com/57706597/163480377-d821a71e-5613-4451-a11e-a0b9dac174d2.png">


Adding only `xpanimes.com##.container` would also hides the video frame when you select a title. 
[Sampel URL](https://www.xpanimes.com/play/centraldc.php/?v=&t=&d=&key=&f=&w=&w2=&z=&dc=&cr=https://fy.v.vrv.co/evs3/861ba8dcf8a3c269f34b617aa8be5131/assets/861ba8dcf8a3c269f34b617aa8be5131_4433302.mp4?Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cCo6Ly9wbC5jcnVuY2h5cm9sbC5jb20vZXZzMy84NjFiYThkY2Y4YTNjMjY5ZjM0YjYxN2FhOGJlNTEzMS9hc3NldHMvODYxYmE4ZGNmOGEzYzI2OWYzNGI2MTdhYThiZTUxMzFfNDQzMzMwMi5tcDQvY2xpcEZyb20vMDAwMC9jbGlwVG8vMTIwMDAwL2luZGV4Lm0zdTgiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE2NDk1MTQ2MzF9fX1dfQ__&Signature=Bq96HBlH9fv1eEBkDpXYw3QIo9N6Jk-tSCDh2C~bAwN5Y6nJT3-fvBEzIVaTEBx5va01ugkh8DYgjZQhMuQb0AUpMZAyUmUP9B0l6p9l6gYaq32L46--B05~s8Pg5tsZmHsosEzme05aCNKnTRYNWXBq-MxbsXciB3KWPQoO4cfD6caXKDm~NxJPTmAXlfQG7Jp5AhwKMe8tRsGtMDPaMgrbcLoqh5wTvM1e8Fu3fNzX70Cf-qOJRUAtQSxUDp~npV3LtC7ly6TFjY0Gkq2wJu-3PTG3ooee3QCUL5AxjcKUkPdEaI1OjjBm2UOGMz6nwRosRDT~CbzvpHzhKThv6g__&Key-Pair-Id=APKAJMWSQ5S7ZB3MF5VA)

<img width="1115" alt="xpa3" src="https://user-images.githubusercontent.com/57706597/163480384-daf4d17b-1ac3-42af-ab86-63804963cd43.png">
