### PR TITLE
A: https://www.tvpop.com.br/

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_hide.txt
+++ b/easylistportuguese/easylistportuguese_specific_hide.txt
@@ -369,3 +369,4 @@ xpanimes.com##.container > div[style*="z-index:"]
 fimdalinha.com.br##div[class*="banner-"]
 fimdalinha.com.br##.wp-container-2
 smallseotools.com##a[title="read more"]
+tvpop.com.br##.up-floating


### PR DESCRIPTION

Hide sticky bottom placeholder at https://www.tvpop.com.br/82126/globo-recusou-programa-de-drags-apresentado-por-xuxa-e-ivete-sangalo/

Screenshot:
<img width="1512" alt="Screenshot 2022-08-08 at 11 21 59" src="https://user-images.githubusercontent.com/65717387/183385252-ca1f96e5-7f94-4e80-991e-2207a87f2a0e.png">