### PR TITLE
M: Update

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_hide.txt
+++ b/easylistportuguese/easylistportuguese_specific_hide.txt
@@ -11,6 +11,7 @@ crusoe.uol.com.br###gpt-leaderboard
 oantagonista.uol.com.br###gpt_box_sidebar
 conjur.com.br###leaderboard1
 conjur.com.br###leaderboard2
+agroolhar.com.br,olharconceito.com.br,olharjuridico.com.br###luckpub
 evangelionbr.com###media_image-10
 tag.jn.pt###mrec
 ig.com.br###mrec2
@@ -58,6 +59,7 @@ slatual.com.br##.banner_side_home
 slatual.com.br##.banner_text
 otimafm.com.br##.banners-posicao
 bahianoticias.com.br##.banners_topo
+agroolhar.com.br,olharconceito.com.br,olharjuridico.com.br,olhardireto.com.br##.bannerstopo
 techbreak.ig.com.br##.barraverborum
 ig.com.br##.betOrBillboard
 folha.uol.com.br##.block--pub-super


### PR DESCRIPTION
Top banners on the group of correlated websites:
https://agroolhar.com.br/
https://www.olhardireto.com.br/
https://www.olharconceito.com.br/
https://www.olharjuridico.com.br/

The top luck.bet banner shows to appear an all pages when first accessed. 
The green banner (##.bannerstopo) shows up selectively but I come across  also on all domains. 
<img width="835" alt="image" src="https://user-images.githubusercontent.com/33602691/205035064-9e7d5544-975d-4696-b015-bac7b2070fa5.png">

